### PR TITLE
ENH: summarize library versions

### DIFF
--- a/ads_deploy/docs.py
+++ b/ads_deploy/docs.py
@@ -241,11 +241,16 @@ def _build_library_versions(plc):
         library_name, version_and_vendor = text.split(', ')
         version, vendor = version_and_vendor.split('(')
         vendor = vendor.rstrip(')')
+        version = version.strip()
+
+        if version == '*':
+            version = 'Unset'
+
         return (
             library_name,
             {'name': library_name,
              'vendor': vendor,
-             version_key: version.strip(),
+             version_key: version,
              },
         )
 

--- a/ads_deploy/docs.py
+++ b/ads_deploy/docs.py
@@ -233,6 +233,40 @@ def _clean_link(link):
     return link
 
 
+def _build_library_versions(plc):
+    if 'DefaultResolution' not in pytmc_parser.TWINCAT_TYPES:
+        return []
+
+    def parse_library(text, version_key):
+        library_name, version_and_vendor = text.split(', ')
+        version, vendor = version_and_vendor.split('(')
+        vendor = vendor.rstrip(')')
+        return (
+            library_name,
+            {'name': library_name,
+             'vendor': vendor,
+             version_key: version.strip(),
+             },
+        )
+
+    libraries = dict(
+        parse_library(lib.text, version_key='default')
+        for lib in plc.find(pytmc_parser.TWINCAT_TYPES['DefaultResolution'])
+    )
+    resolved = dict(
+        parse_library(lib.text, version_key='version')
+        for lib in plc.find(pytmc_parser.TWINCAT_TYPES['Resolution'])
+    )
+
+    for name, info in resolved.items():
+        if name not in libraries:
+            libraries[name] = info
+        else:
+            libraries[name]['version'] = info['version']
+
+    return list(libraries.values())
+
+
 def build_template_kwargs(solution_path, projects, *, plcs=None, dbd=None):
     solution_name = solution_path.stem if solution_path is not None else None
     render_args = {
@@ -281,6 +315,12 @@ def build_template_kwargs(solution_path, projects, *, plcs=None, dbd=None):
             except Exception:
                 logger.exception('Failed to get data type information')
 
+            try:
+                libraries = _build_library_versions(plc_project)
+            except Exception:
+                logger.exception('Failed to aggregate library versions')
+                libraries = []
+
             plc_info = dict(
                 name=plc_name,
                 obj=plc_project,
@@ -289,6 +329,7 @@ def build_template_kwargs(solution_path, projects, *, plcs=None, dbd=None):
                 data_types=data_types,
                 records=records,
                 record_exceptions=record_exceptions,
+                libraries=libraries,
             )
 
             logger.debug('Records for %s: %d', plc_name,

--- a/ads_deploy/templates/{{tsproj.name}}_{{plc.name}}_summary.rst
+++ b/ads_deploy/templates/{{tsproj.name}}_{{plc.name}}_summary.rst
@@ -43,6 +43,17 @@ Total linter errors: {{ plc.pragma_errors }}
             {% endfor %}{# for item in items #}
         {% endfor %}{# for ... in plc.linter_results #}
 
+
+{{ util.section('Libraries') }}
+
+.. csv-table::
+    :header: Library, Vendor, Default, Version
+    :align: center
+
+    {% for item in plc.libraries | sort(attribute="name") %}
+        {{ item.name }}, {{ item.vendor }}, {{ item.default }}, {{ item.version }}
+    {% endfor %}{# for library... #}
+
 {{ util.section("Symbols") }}
 
 


### PR DESCRIPTION
Library versions in summary. This renders like the following:

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/5139267/92829680-54fa9980-f389-11ea-846d-b4481daed16d.png">

cc @slacAWallace 