### PR TITLE
ENH: link related source code items in auto-generated documentation

### DIFF
--- a/ads_deploy/templates/{{tsproj.name}}_{{plc.name}}_source.rst
+++ b/ads_deploy/templates/{{tsproj.name}}_{{plc.name}}_source.rst
@@ -12,5 +12,14 @@
 
     {{ source.get_source_code() | indent(4) }}
 
+
+{% set related = source.get_source_code() | related_source(source_name, tsproj, plc) %}
+{% if related %}
+Related:
+{% for item in related %}
+    * {{ item }}
+{% endfor %}
+{% endif %}
+
 {% endfor %}{# for dut_name, ... #}
 {% endfor %}{# for source_dict ... #}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Show related source code for DUTs, POUs, GVLs.

## Motivation and Context
Useful for reviewing source code and jumping around.

## How Has This Been Tested?
Locally, only with lcls-twincat-motion.

## Screenshots (if appropriate):
<img width="744" alt="image" src="https://user-images.githubusercontent.com/5139267/127902492-1d090901-d906-4dd8-b4d4-d18c66a9f962.png">
