### PR TITLE
MNT: unpin jinja2, raise pytmc pin

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - jinja2 <3.0
+    - jinja2
     - pytmc >=2.6.9
     - typhos >=1.0
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.6
     - jinja2
-    - pytmc >=2.6.9
+    - pytmc >=2.11.0
     - typhos >=1.0
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytmc>=2.6.9
+pytmc>=2.11.0
 typhos>=1.0
 jinja2
 versioneer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytmc>=2.6.9
 typhos>=1.0
-jinja2<3.0
+jinja2
 versioneer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Unpin Jinja2, allowing for v3 to be installed in ads-deploy-based CI.

## Motivation and Context
* CI is currently failing
* Closes #24 
* Just pushed pytmc tag, which was missing on pypi

## How Has This Been Tested?
* Local testing trying to reproduce #24 
* CI testing will follow and additional PRs may be required 