### PR TITLE
MNT: remove evalcontextfilter usage

### DIFF
--- a/ads_deploy/docs.py
+++ b/ads_deploy/docs.py
@@ -209,9 +209,7 @@ def get_jinja_filters() -> Dict[str, Callable]:
     saw_tsproj = set()
     name_cache = {}
 
-    @jinja2.evalcontextfilter
     def related_source(
-        eval_ctx,
         text,
         source_name: str,
         tsproj: pytmc_parser.TcSmProject,

--- a/ads_deploy/docs.py
+++ b/ads_deploy/docs.py
@@ -342,7 +342,7 @@ def main(
         solution_path, projects, plcs=plcs, dbd=dbd
     )
 
-    @functools.lru_cache
+    @functools.lru_cache(maxsize=None)
     def get_template_source(template_path: pathlib.Path) -> str:
         with open(template_path, "rt") as fp:
             return fp.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytmc>=2.11.0
 typhos>=1.0
-jinja2
+jinja2<3.1
 versioneer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytmc>=2.11.0
 typhos>=1.0
-jinja2<3.1
+jinja2
 versioneer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR started out as a pin of jinja2 to `< 3.1`, but I think we can safely move forward by removing references without concern for back/forward-compatibility with differing jinja versions. If we get bitten once more, it'll be time to pin.

* `evalcontextfilter` deprecated in Jinja2 3.1:
> Deprecated since version 3.0: Will be removed in Jinja 3.1. Use [pass_eval_context()](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.pass_eval_context) instead.
* pytmc uses this as well, related PR: https://github.com/pcdshub/pytmc/pull/280
* Minor fix for lrucache as I had a local ads-deploy environment with Python 3.7 that failed due to a Python standard lib change in 3.8