### PR TITLE
Setting WINDOWS_ADS_IOC_TOP to use R0.8.0

### DIFF
--- a/ads_deploy/windows/conda_config.cmd
+++ b/ads_deploy/windows/conda_config.cmd
@@ -1,5 +1,5 @@
 SET ADS_DEPLOY_CONDA_ENV=ads-deploy-2.9.1
-SET WINDOWS_ADS_IOC_TOP=c:/Repos/ads-ioc/R0.6.1
+SET WINDOWS_ADS_IOC_TOP=c:/Repos/ads-ioc/R0.8.0
 
 IF "%UseDocker%" == "0" (
     echo * Using ads-deploy conda environment: %ADS_DEPLOY_CONDA_ENV%


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I checked out R0.8.0 here
![image](https://github.com/user-attachments/assets/3c776dd0-f06b-49e7-b305-6461190556b3)
And I updated the WINDOWS_ADS_IOC_TOP to use that version. Hopefully, that's all I need to do. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ECS-773, as part of the effort to have all plc iocs use R0.8.0 and restart automatically after bulk read failures I thought we should also make that the default version here for new plcs too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure how to test this on windows. Maybe there's a way to make twincat use a custom version of ads-deploy somehow?

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
