### PR TITLE
Updating ads-deploy to latest pytmc and ads-ioc, upgraded dependencie…

### DIFF
--- a/ads_deploy/windows/add_on.sh
+++ b/ads_deploy/windows/add_on.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -e
+export LC_ALL=C
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+WINDOWS_ADS_IOC_TOP="$1"
+
+source /c/miniconda/etc/profile.d/conda.sh
+
+source "${SCRIPT_PATH}/conda_config.sh"
+conda activate $ADS_DEPLOY_CONDA_ENV
+
+CONDA_ENV_PATH="${CONDA_PREFIX:-}"
+if [[ -z "$CONDA_ENV_PATH" ]]; then
+    die "CONDA_PREFIX is not set. Please activate your conda env first!"
+fi
+
+# Find the correct Python binary inside the environment
+PYTHON="$(conda run -n $ADS_DEPLOY_CONDA_ENV which python 2>/dev/null || which python)"
+PYTHON_BASENAME="$(basename "$PYTHON")"
+
+if [[ -z "$PYTHON" || ! -f "$PYTHON" ]]; then
+    die "Active python executable not found!"
+fi
+
+PYTHON3="$(dirname "$PYTHON")/python3${PYTHON_BASENAME#python}"
+
+if [[ ! -f "$PYTHON3" ]]; then
+    if [[ "$OSTYPE" =~ "msys" || "$OSTYPE" =~ "cygwin" || "$PYTHON_BASENAME" =~ ".exe" ]]; then
+        cp "$PYTHON" "$PYTHON3" || die "Unable to copy $PYTHON to $PYTHON3"
+        echo "Copied $PYTHON to $PYTHON3"
+    else
+        ln -s "$PYTHON" "$PYTHON3" || die "Unable to symlink $PYTHON to $PYTHON3"
+        echo "Symlinked $PYTHON to $PYTHON3"
+    fi
+fi
+
+# 2. Clone or update the master branch
+MASTER_DIR="${WINDOWS_ADS_IOC_TOP}/master"
+REPO_URL="https://github.com/pcdshub/ioc-common-ads-ioc.git"
+
+if [[ -d "$MASTER_DIR/.git" ]]; then
+    cd "$MASTER_DIR"
+    git status > /dev/null 2>&1 || die "Git repo not valid: $MASTER_DIR"
+    git checkout master
+    git pull origin master
+    echo "Master branch updated."
+else
+    mkdir -p "${WINDOWS_ADS_IOC_TOP}"
+    git clone "$REPO_URL" "$MASTER_DIR"
+    echo "Master branch cloned."
+fi
+
+# 3. Get latest release tag from GitHub
+LATEST_TAG="$(curl -s https://api.github.com/repos/pcdshub/ioc-common-ads-ioc/releases/latest | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//;s/"//g')"
+
+echo "Latest tag is: $LATEST_TAG"
+
+RELEASE_DIR="${WINDOWS_ADS_IOC_TOP}/${LATEST_TAG}"
+
+# 4. Clone or update the release branch
+if [[ -d "$RELEASE_DIR/.git" ]]; then
+    cd "$RELEASE_DIR"
+    git status > /dev/null 2>&1 || die "Git repo not valid: $RELEASE_DIR"
+    git checkout "$LATEST_TAG"
+    git pull origin "$LATEST_TAG"
+    echo "Release $LATEST_TAG updated."
+else
+    mkdir -p "${WINDOWS_ADS_IOC_TOP}"
+    git clone --single-branch --branch "$LATEST_TAG" "$REPO_URL" "$RELEASE_DIR"
+    echo "Release $LATEST_TAG cloned."
+fi
+
+# 5. Update conda_config.cmd with the latest path (one replacement, add blank line)
+CONFIG_FILE="$SCRIPT_PATH/conda_config.cmd"
+TEMP_CONFIG="${CONFIG_FILE}.tmp"
+
+LATEST_IOC_TOP="c:/Repos/ads-ioc/$LATEST_TAG"
+
+if [[ ! -d "${WINDOWS_ADS_IOC_TOP}/${LATEST_TAG}" ]] || [[ -z "$LATEST_TAG" ]]; then
+    LATEST_IOC_TOP="c:/Repos/ads-ioc/master"
+fi
+
+awk -v new_path="$LATEST_IOC_TOP" '
+    BEGIN { replaced=0 }
+    /WINDOWS_ADS_IOC_TOP=/ && replaced==0 {
+        print "SET WINDOWS_ADS_IOC_TOP=" new_path
+        print ""
+        replaced=1
+        next
+    }
+    { print }
+' "$CONFIG_FILE" > "$TEMP_CONFIG"
+
+mv "$TEMP_CONFIG" "$CONFIG_FILE"
+echo "Updated $CONFIG_FILE with WINDOWS_ADS_IOC_TOP=$LATEST_IOC_TOP"
+
+# echo "All steps complete."

--- a/ads_deploy/windows/add_on.sh
+++ b/ads_deploy/windows/add_on.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
-
+##############################################################################
+# add_on.sh
+#
+# - Ensures the active conda environment's Python executable is available as "python3"
+# - Clones or updates both the master and latest release branches of
+#   https://github.com/pcdshub/ioc-common-ads-ioc.git under the given WINDOWS_ADS_IOC_TOP
+# - Detects the latest GitHub release tag using curl/grep/sed (jq optional)
+# - Clones or updates the latest release branch in the repo directory
+# - Updates the first occurrence of "WINDOWS_ADS_IOC_TOP=" in conda_config.cmd,
+#
+# Usage:
+#     bash ads_deploy_update.sh <WINDOWS_ADS_IOC_TOP>
+#
+# Requirements:
+# - Bash (Git Bash, MSYS2, or compatible)
+# - Conda (Miniconda/Anaconda) properly installed with bash integration
+# - curl, git, awk, sed, grep (jq optional for improved tag parsing)
+#
+# Arguments:
+#   WINDOWS_ADS_IOC_TOP (string): Path under which master/latest branches will be stored locally.
+##############################################################################
 set -e
 export LC_ALL=C
 

--- a/ads_deploy/windows/build_ioc.cmd
+++ b/ads_deploy/windows/build_ioc.cmd
@@ -12,7 +12,7 @@ IF %AdsDeployUseDocker% EQU 1 (
     @echo - Attempting to build the IOC
     %RunDocker% %DockerImage% "find '%IocMountPath%/iocBoot' -type d -maxdepth 1 -name 'ioc*' -exec make -C {} \;"
 ) ELSE (
-    C:\miniconda\envs\ads-deploy-2.9.1\Library\usr\bin\bash.exe --login -c "find '%SolutionDir:\=/%/iocBoot' -type d -maxdepth 1 -name 'ioc*' -exec bash --login %AdsDeployWindowsScripts:\=/%/build.sh '{}' '%WINDOWS_ADS_IOC_TOP:\=/%/' \;"
+    bash.exe --login -c "find '%SolutionDir:\=/%/iocBoot' -type d -maxdepth 1 -name 'ioc*' -exec bash --login %AdsDeployWindowsScripts:\=/%/build.sh '{}' '%WINDOWS_ADS_IOC_TOP:\=/%/' \;"
 )
 
 if %ERRORLEVEL% NEQ 0 (

--- a/ads_deploy/windows/conda_config.cmd
+++ b/ads_deploy/windows/conda_config.cmd
@@ -1,5 +1,5 @@
-SET ADS_DEPLOY_CONDA_ENV=ads-deploy-2.9.1
-SET WINDOWS_ADS_IOC_TOP=c:/Repos/ads-ioc/R0.8.0
+SET ADS_DEPLOY_CONDA_ENV=ads-deploy-2.12.0
+SET WINDOWS_ADS_IOC_TOP=c:/Repos/ads-ioc/R1.0.1
 
 IF "%UseDocker%" == "0" (
     echo * Using ads-deploy conda environment: %ADS_DEPLOY_CONDA_ENV%

--- a/ads_deploy/windows/conda_config.sh
+++ b/ads_deploy/windows/conda_config.sh
@@ -1,1 +1,1 @@
-export ADS_DEPLOY_CONDA_ENV=ads-deploy-2.9.1
+export ADS_DEPLOY_CONDA_ENV=ads-deploy-2.12.0

--- a/ads_deploy/windows/post_install.sh
+++ b/ads_deploy/windows/post_install.sh
@@ -10,7 +10,7 @@
 # - Updates the first occurrence of "WINDOWS_ADS_IOC_TOP=" in conda_config.cmd,
 #
 # Usage:
-#     bash ads_deploy_update.sh <WINDOWS_ADS_IOC_TOP>
+#     bash add_on.sh <WINDOWS_ADS_IOC_TOP>
 #
 # Requirements:
 # - Bash (Git Bash, MSYS2, or compatible)
@@ -28,8 +28,10 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 WINDOWS_ADS_IOC_TOP="$1"
 
+# Source conda shell integration for Bash
 source /c/miniconda/etc/profile.d/conda.sh
 
+# Source config for environment name
 source "${SCRIPT_PATH}/conda_config.sh"
 conda activate $ADS_DEPLOY_CONDA_ENV
 
@@ -38,8 +40,8 @@ if [[ -z "$CONDA_ENV_PATH" ]]; then
     die "CONDA_PREFIX is not set. Please activate your conda env first!"
 fi
 
-# Find the correct Python binary inside the environment
-PYTHON="$(conda run -n $ADS_DEPLOY_CONDA_ENV which python 2>/dev/null || which python)"
+# Find python in the activated conda environment
+PYTHON="$(which python)"
 PYTHON_BASENAME="$(basename "$PYTHON")"
 
 if [[ -z "$PYTHON" || ! -f "$PYTHON" ]]; then
@@ -117,5 +119,3 @@ awk -v new_path="$LATEST_IOC_TOP" '
 
 mv "$TEMP_CONFIG" "$CONFIG_FILE"
 echo "Updated $CONFIG_FILE with WINDOWS_ADS_IOC_TOP=$LATEST_IOC_TOP"
-
-# echo "All steps complete."

--- a/conda_env_base.yml
+++ b/conda_env_base.yml
@@ -1,7 +1,7 @@
 epics-base
 happi
-ipython>=7.10
-pydm==1.10.1
-python>=3.8,<3.9
-pytmc==2.9.1
-typhos>=1.0
+ipython>=8.36.0
+pydm>=1.27.0
+python==3.12.10
+pytmc>=2.18.2
+typhos>=4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytmc>=2.11.0
-typhos>=1.0
+pytmc>=2.19.0
+typhos>=4.2.0
 jinja2
 versioneer

--- a/setup_conda_on_windows.cmd
+++ b/setup_conda_on_windows.cmd
@@ -58,8 +58,10 @@ IF %ERRORLEVEL% NEQ 0 (
     GOTO :ConfigureFailure
 )
 
-bash -c "git clone https://github.com/pcdshub/ads-ioc/ '%WINDOWS_ADS_IOC_TOP%'/master || (cd '%WINDOWS_ADS_IOC_TOP%'/master && git pull origin master)"
-bash -c "git clone --single-branch --branch R0.2.4 '%WINDOWS_ADS_IOC_TOP%'/master '%WINDOWS_ADS_IOC_TOP%'/R0.2.4"
+@echo off
+REM ssh-agent must be setup on shell invoking this line.
+REM install ads-deploy from git bash( if you setup you ssh agent there):  cmd.exe /c setup_conda_on_windows.cmd
+bash --login -c "$(pwd)/ads_deploy/windows/add_on.sh '%WINDOWS_ADS_IOC_TOP%'"
 
 REM NOTE: bash -c "mkdir -p /reg/g/pcds/epics/ioc/common/ads-ioc"
 REM these paths are possible, but eventually are broken by how make mangles

--- a/setup_conda_on_windows.cmd
+++ b/setup_conda_on_windows.cmd
@@ -58,7 +58,6 @@ IF %ERRORLEVEL% NEQ 0 (
     GOTO :ConfigureFailure
 )
 
-@echo off
 REM ssh-agent must be setup on shell invoking this line.
 REM install ads-deploy from git bash( if you setup you ssh agent there):  cmd.exe /c setup_conda_on_windows.cmd
 bash --login -c "$(pwd)/ads_deploy/windows/add_on.sh '%WINDOWS_ADS_IOC_TOP%'"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Updating ads-deploy to the latest pytmc and ads-ioc, upgraded dependencies to the current pcds conda
- Added a bash script to fix the issue with Python3 missing in the ads-deploy env while building the ioc, and pull the latest tag after installing the env, the newest release is now used as the default ads-ioc

**Note**: adjust the SSH key and the ssh-agent for your shell. On Git-Bash run: `cmd.exe /c setup_conda_on_windows.cmd`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-9455
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://jira.slac.stanford.edu/browse/ECS-9455
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-9455
<!--
## Screenshots (if appropriate):
-->
<img width="3402" height="1915" alt="build-ioc-ads-deploy-2 12 0" src="https://github.com/user-attachments/assets/3223780d-ffc5-4951-b60d-ca0f7c79f7ca" />

